### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ export default defineConfig({
     svelteInlineComponent(), // <------ here
   ],
   test: {
-    global: true,
+    globals: true,
     environment: 'jsdom',
   },
   resolve: {


### PR DESCRIPTION
I'm not sure if vitest has changed since the README was written, but it seems to want `globals` rather than `global` now.